### PR TITLE
Add MCP server for web searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ smarterwebsearchmcp/
     search_critic.py
     web_search_tool.py
 ```
+
+The repository also provides a small MCP server script that exposes the search
+agents over the [FastMCP](https://pypi.org/project/fastmcp/) server:
+
+```bash
+fastmcp run -t sse mcp_server.py:mcp
+```

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,25 @@
+from fastmcp import FastMCP
+from smarterwebsearchmcp.manager import WebSearchManager
+
+mcp = FastMCP("Smarter Web Search")
+
+async def _perform_search(query: str) -> str:
+    """Run the web search agents and return the results."""
+    manager = WebSearchManager()
+    # Plan and perform searches, reusing the manager internals
+    plan = await manager._plan_searches(query)
+    results = await manager._perform_searches(query, plan)
+    output = []
+    for item, text in results:
+        output.append(f"# {item.query}\n{text}")
+    return "\n\n".join(output)
+
+
+@mcp.tool()
+async def web_search(query: str) -> str:
+    """Search the web using the built-in search agents."""
+    return await _perform_search(query)
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary
- add a small FastMCP server that exposes the search agents
- document how to run the MCP server

## Testing
- `python -m py_compile mcp_server.py smarterwebsearchmcp/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684129b6ce1c832ebebf08fa2ea4e836